### PR TITLE
Quote column names in SET clause of UPDATEs.

### DIFF
--- a/lib/vendor/propel/util/BasePeer.php
+++ b/lib/vendor/propel/util/BasePeer.php
@@ -388,7 +388,7 @@ class BasePeer
 
 				$sql = "UPDATE " . $tableName . " SET ";
 				foreach($updateTablesColumns[$tableName] as $col) {
-					$sql .= substr($col, strpos($col, '.') + 1) . " = ?,";
+					$sql .= "`" . substr($col, strpos($col, '.') + 1) . "` = ?,";
 				}
 
 				$sql = substr($sql, 0, -1) . " WHERE " . $sqlSnippet;


### PR DESCRIPTION
Otherwise, naming columns after reserved words, like `order`, doesn't work.
