### PR TITLE
Handle non-standard port for HTTPS protocol.

### DIFF
--- a/lib/request/sfWebRequest.class.php
+++ b/lib/request/sfWebRequest.class.php
@@ -407,29 +407,20 @@ class sfWebRequest extends sfRequest
   public function getUriPrefix()
   {
     $pathArray = $this->getPathInfoArray();
-    if ($this->isSecure())
-    {
-      $standardPort = '443';
-      $protocol = 'https';
-    }
-    else
-    {
-      $standardPort = '80';
-      $protocol = 'http';
-    }
-
     $host = explode(":", $this->getHost());
+    $protocol = $this->isSecure() ? 'https' : 'http';
+
     if (count($host) == 1)
     {
       $host[] = isset($pathArray['SERVER_PORT']) ? $pathArray['SERVER_PORT'] : '';
     }
 
-    if ($host[1] == $standardPort || empty($host[1]))
+    if (($this->isSecure() && $host[1] == '443') || $host[1] == '80' || empty($host[1]))
     {
       unset($host[1]);
     }
 
-    return $protocol.'://'.implode(':', $host);;
+    return $protocol.'://'.implode(':', $host);
   }
 
   /**


### PR DESCRIPTION
The current ELB appends `HTTP_X_FORWARDED_PROTO: HTTPS` in the header
and forward it to our web servers via port 80 (standart PORT for HTTP).
Since the HTTP_X_FORWARDED_PROTO does not match up to the standard HTTPS
PORT number(443), `getUriPrefix` will append PORT number to the base URL
to cover non-standard use case.
